### PR TITLE
Allow validate-all handlers

### DIFF
--- a/ocfagent/agent.py
+++ b/ocfagent/agent.py
@@ -101,7 +101,7 @@ class ResourceAgent(object):  # pylint: disable=R0902
 		# check if the action is a valid implemented handler
 		action = sys.argv[1]
 		if action not in self.handlers.keys() + ["meta-data", "usage"]:
-			raise RuntimeError("Specified action %s is not a defined handler" % action)
+			raise RuntimeError("Specified action %s does not have a defined handler" % action)
 		return action
 
 	def cmdline_call(self):
@@ -140,7 +140,7 @@ class ResourceAgent(object):  # pylint: disable=R0902
 						continue
 					handler_dict[var] = func.func_defaults[i]
 					i += 1
-				# Excpect timeout to be always implemented. This is a should in
+				# Expect timeout to be always implemented. This is a should in
 				# http://www.linux-ha.org/doc/dev-guides/_metadata.html
 				# but we will force this here to be present
 				if "timeout" not in handler_dict.keys():
@@ -204,7 +204,7 @@ class ResourceAgent(object):  # pylint: disable=R0902
 				if entry not in self.OCF_ENVIRON.keys():
 					raise error.OCFErrArgs("Mandatory environment variable %s not found" % entry)
 
-			# Excpect a OCF RA Version 1.0 here
+			# Expect a OCF RA Version 1.0 here
 			ocf_ra_version = "%i.%i" % (int(self.OCF_ENVIRON["OCF_RA_VERSION_MAJOR"]), int(self.OCF_ENVIRON["OCF_RA_VERSION_MINOR"]))
 			assert ocf_ra_version == "1.0"
 

--- a/ocfagent/agent.py
+++ b/ocfagent/agent.py
@@ -95,14 +95,24 @@ class ResourceAgent(object):  # pylint: disable=R0902
 			self.parse_parameters()
 
 	def get_action(self):
+		"""validate the requested action. Raise a RuntimeError if the action
+		is unexpected, but return OCF_ERR_UNIMPLEMENTED if the action has merely
+		not been implemented."""
 		# if no cmdline parameter is given, call action is usage
 		if len(sys.argv) <= 1:
 			return "usage"
 		# check if the action is a valid implemented handler
 		action = sys.argv[1]
-		if action not in self.handlers.keys() + ["meta-data", "usage"]:
-			raise RuntimeError("Specified action %s does not have a defined handler" % action)
-		return action
+		# check if the action is a valid implemented handler
+		if action in ["meta-data", "usage"]:
+			return action
+		elif action in self.__OCF_VALID_HANDLERS:
+			if action in self.handlers.keys():
+				return action
+			else:
+				raise error.OCFErrUnimplemented("Specified action %s does not have a defined handler" % action)
+		else:
+			raise RuntimeError("Specified action %s is invalid" % action)
 
 	def cmdline_call(self):
 		"""main function, which should be called. Expects cmd line argument and a implemented action"""


### PR DESCRIPTION
This PR adds support for validate-all handlers by internally converting between a "validate-all" action to a handle_validate_all function.
Some minor cleanups are also included.
This supersedes #3, which I cannot reopen because of the force push.